### PR TITLE
`:root`/dark mode: Set background color

### DIFF
--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -36,9 +36,8 @@ License: BSD
 	:root {
 		--special-text-color: hsla(60, 50%, 70%, 0.75);
 		--border-color: white;
-		color: #f0f0f0;
 	}
-	body {
+	body, :root {
 		background-color: #2b303b;
 		background: #2b303b;
 		color: #f0f0f0;


### PR DESCRIPTION
@holzschu

## Summary
 * Scrolling to the end of long menus would previously reveal the (white) background of the root element. When in dark mode, it is expected for the document to have a dark-grey background.
 * Note: This is **untested**!